### PR TITLE
Add tooltips directive

### DIFF
--- a/src/app/demo/demo.module.ts
+++ b/src/app/demo/demo.module.ts
@@ -9,6 +9,7 @@ import {AppComponent} from './app.component';
 import {MonacoConfigService} from '../exercise/services/monaco-config.service';
 import {ExerciseModule} from '../exercise/exersice.module';
 import {SlidesRoutes} from '../presentation/slide-routes';
+import {TooltipsModule} from "../tooltips/tooltips.module";
 
 
 export const routes = SlidesRoutes.get(DemoComponent);
@@ -27,7 +28,8 @@ export function monacoReady() {
     HttpModule,
     SharedModule,
     ExerciseModule,
-    RouterModule.forRoot(routes)
+    RouterModule.forRoot(routes),
+    TooltipsModule
   ],
   providers: [{
     provide: APP_INITIALIZER,

--- a/src/app/tooltips/tooltips.directive.spec.ts
+++ b/src/app/tooltips/tooltips.directive.spec.ts
@@ -1,0 +1,8 @@
+import { TooltipsDirective } from './tooltips.directive';
+
+describe('TooltipsDirective', () => {
+  it('should create an instance', () => {
+    const directive = new TooltipsDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/tooltips/tooltips.directive.ts
+++ b/src/app/tooltips/tooltips.directive.ts
@@ -1,0 +1,57 @@
+import {Directive, Input, ElementRef} from '@angular/core';
+
+/*
+This directive adds tooltips to the provided text
+
+Usage in template:
+<app-slide [ng-tooltips]="tooltips">
+
+...
+tooltips = [
+ {
+  match:'Angular',
+  text:'This is Angular',
+  fontSize: 40 ---optional
+ }
+];
+
+ */
+
+@Directive({
+  selector: '[ng-tooltips]'
+})
+export class TooltipsDirective {
+  @Input('ng-tooltips') matches = [];
+  constructor(private el: ElementRef) { }
+
+  ngAfterViewInit(){
+    let codeHTML = this.el.nativeElement.innerHTML;
+    this.matches.forEach((item, i) => {
+      codeHTML = codeHTML.replace(item.match, '<span class="popup-src-'+ i + '">' + item.match + '</span>');
+    });
+    this.el.nativeElement.innerHTML = codeHTML;
+
+    this.matches.forEach((item, i) => {
+      let text = this.el.nativeElement.querySelector('.popup-src-' + i);
+      let newPopup = document.createElement('div');
+      newPopup.className = 'popup';
+
+      let popupMessage = document.createElement('div');
+      let popupArrow = document.createElement('div');
+      popupMessage.className = 'popup-message';
+      popupArrow.className = 'popup-arrow';
+      popupMessage.innerHTML = item.text;
+      if (item.fontSize){
+        popupMessage.style['font-size'] = item.fontSize + 'px';
+      }
+
+      newPopup.appendChild(popupMessage);
+      newPopup.appendChild(popupArrow);
+
+      this.el.nativeElement.append(newPopup);
+      newPopup.style.position = 'absolute';
+      newPopup.style.top = text.offsetTop - (newPopup.offsetHeight) + 5 + 'px';
+      newPopup.style.left = text.offsetLeft + (text.offsetWidth) + 'px';
+    });
+  }
+}

--- a/src/app/tooltips/tooltips.module.ts
+++ b/src/app/tooltips/tooltips.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { TooltipsDirective } from './tooltips.directive';
+
+@NgModule({
+  imports: [
+    CommonModule
+  ],
+  declarations: [TooltipsDirective],
+  exports:[TooltipsDirective]
+})
+export class TooltipsModule { }

--- a/src/styles.css
+++ b/src/styles.css
@@ -57,3 +57,18 @@ h1 {
 h2 {
   font-size: 40px;
 }
+
+
+.popup-message{
+  padding:5px 5px 0 5px;
+  background:black;
+  color:white;
+  font-size: 20px;
+}
+.popup-arrow{
+  width: 0;
+  height: 0;
+  border-left: 0px solid transparent;
+  border-right: 20px solid transparent;
+  border-top: 8px solid black;
+}


### PR DESCRIPTION
This PR proposes adding a feature that will display tooltips for certain text.
In this pull request it was accomplished by creating a directive.

![image](https://cloud.githubusercontent.com/assets/14893203/25081947/715f6a02-231b-11e7-84f9-a8060df32e5e.png)

In order to use the directive we need to pass it an array of objects with keys `match`, `text` and optional `fontSize`.
```
tooltips = [
 {
  match:'Angular',
  text:'This is Angular',
  fontSize: 40 //optional
 }
];
```
Then use the directive in template:
`<app-slide [ng-tooltips]="tooltips">`
