### PR TITLE
Empty code  fix

### DIFF
--- a/src/app/exercise/editor/editor.component.ts
+++ b/src/app/exercise/editor/editor.component.ts
@@ -85,6 +85,7 @@ export class EditorComponent implements AfterViewInit, OnChanges, OnDestroy {
     let model = this.monacoConfigService.monaco.editor.getModel(this.file.path);
     if (!model) {
       model = this.monacoConfigService.monaco.editor.createModel(this.file.code, this.file.type, this.file.path);
+      model.isSingleEditorModel = true;
     }
 
     this.code = this.file.code;

--- a/src/app/exercise/services/monaco-config.service.ts
+++ b/src/app/exercise/services/monaco-config.service.ts
@@ -102,7 +102,7 @@ export class MonacoConfigService {
     const models = monaco.editor.getModels();
 
     if (models.length) {
-      models.forEach(model => model.dispose());
+      models.filter(model=>!model.isSingleEditorModel).forEach(model => model.dispose());
     }
 
     files.map(file => {


### PR DESCRIPTION
When going from number_type slide to string_type slide, code would disappear.  This pull request fixes it.

Fixes #46.